### PR TITLE
chore: separated workflow to publish builds to store

### DIFF
--- a/.github/workflows/chrome.yml
+++ b/.github/workflows/chrome.yml
@@ -1,8 +1,6 @@
-name: "Submit to Web Store"
+name: "Submit to Chrome Web Store"
 on:
   push:
-    branches:
-      - master
     tags:
       - v*
 
@@ -31,11 +29,8 @@ jobs:
           cache: "pnpm"
       - name: Build Chrome artifact
         run: pnpm build --target=chrome-mv3 --zip
-      - name: Build Firefox artifact
-        run: pnpm build --target=firefox-mv2 --zip
       - name: Browser Platform Publish
         uses: PlasmoHQ/bpp@v3
         with:
           keys: ${{ secrets.SUBMIT_KEYS }}
           chrome-file: build/chrome-mv3-prod.zip
-          firefox-file: build/firefox-mv2-prod.zip

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -1,0 +1,36 @@
+name: "Submit to Firefox Add-ons"
+on:
+  push:
+    tags:
+      - v*
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache pnpm modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+      - uses: pnpm/action-setup@v2.2.4
+        with:
+          version: latest
+          run_install: true
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3.4.1
+        with:
+          node-version: 16.x
+          cache: "pnpm"
+      - name: Build Firefox artifact
+        run: pnpm build --target=firefox-mv2 --zip
+      - name: Browser Platform Publish
+        uses: PlasmoHQ/bpp@v3
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}
+          firefox-file: build/firefox-mv2-prod.zip


### PR DESCRIPTION
- [x] Workflow to publish build in to the Chrome Web Store
- [x] Workflow to publish build in to the Firefox Add-ons
- [x] Publish at only push tag events 